### PR TITLE
Fix handling of several optional arguments in `run_pipeline.py`

### DIFF
--- a/run_magician.py
+++ b/run_magician.py
@@ -188,8 +188,8 @@ if __name__ == "__main__":
     cluster_cmd = args.cluster
     snake_cores = args.cores
     snake_flags = args.snake_flags[0].split()
-    if args.workflow_config_file:
-        default_config_file = pathlib.Path(args.workflow_config_file).resolve()
+    if args.config_file:
+        default_config_file = pathlib.Path(args.config_file).resolve()
 
     snake_command = get_snake_cmd(community_file, target_result, profiletype, profilename,
                                   read_length, insert_size,

--- a/run_magician.py
+++ b/run_magician.py
@@ -187,7 +187,9 @@ if __name__ == "__main__":
     insert_size = args.insert_size
     cluster_cmd = args.cluster
     snake_cores = args.cores
-    snake_flags = args.snake_flags[0].split()
+    snake_flags = []
+    if args.snake_flags:
+        snake_flags = args.snake_flags[0].split()
     if args.config_file:
         default_config_file = pathlib.Path(args.config_file).resolve()
 


### PR DESCRIPTION
* the `--config_file` argument is now actually what's checked for
* a default of no flags is set for `--snake_flags` so the pipeline doesn't need a blank flag to start